### PR TITLE
(Base #38) 서버의 npm run dev 정상 동작하도록 처리

### DIFF
--- a/take_break_server/package.json
+++ b/take_break_server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "dev": "webpack --watch",
+    "dev": "webpack --watch --env.NODE_ENV=development",
     "start": "node dist/bundle.js",
     "test": "jest --watch"
   },

--- a/take_break_server/webpack.config.js
+++ b/take_break_server/webpack.config.js
@@ -2,7 +2,8 @@ const path = require('path');
 var nodeExternals = require('webpack-node-externals');
 const NodemonPlugin = require('nodemon-webpack-plugin'); // Ding
 
-module.exports = {
+module.exports = env => ({
+  mode: env.NODE_ENV,
   entry: ['babel-polyfill', './app.ts'],
   target: 'node', // in order to ignore built-in modules like path, fs, etc.
   externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
@@ -33,4 +34,4 @@ module.exports = {
   plugins: [
     new NodemonPlugin() // Dong
   ]
-};
+});


### PR DESCRIPTION
## Description

- `npm run dev` 수행시 .env의 development 관련 설정을 읽어야하는데 production 관련 설정을 읽어들이는 현상 수정

## Related Issue

#40 

## How Has This Been Tested?

1. production 환경변수 미설정, development 환경변수 설정 후 `npm run dev`

## Screenshots
