### PR TITLE
(Base #43) Organization 생성/삭제 API

### DIFF
--- a/take_break_server/README.md
+++ b/take_break_server/README.md
@@ -28,6 +28,24 @@
   $ npm run dev
   ```
 
+### Test
+
+- reset database
+
+  ```
+  $ NODE_ENV=test npx sequelize db:drop
+  $ NODE_ENV=test npx sequelize db:create
+  $ NODE_ENV=test npx sequelize db:migrate
+  ```
+
+- run test
+
+  ```
+  $ npm run test
+  ```
+
+  기본적으로 watch 모드로 동작합니다. <kbd>a<kbd> 키를 눌려 전체 테스트 수행
+
 ### How to make model
 
 [Migration Docs](http://docs.sequelizejs.com/manual/migrations.html)

--- a/take_break_server/app.ts
+++ b/take_break_server/app.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import passport from './passport';
 import indexRouter from './routes';
 import usersRouter from './routes/users';
+import organizationsRouter from './routes/organizations';
 
 import authRouter from './routes/auth';
 import prepareDatabase from './prepareDatabase';
@@ -34,6 +35,7 @@ app.use(passport.initialize());
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 app.use('/auth', authRouter);
+app.use('/organizations', organizationsRouter);
 
 if (process.env.NODE_ENV !== 'test') {
   app.listen(PORT, () => {

--- a/take_break_server/models/organization.ts
+++ b/take_break_server/models/organization.ts
@@ -3,7 +3,12 @@ import * as db from '../database/db';
 import { Model, DataTypes } from 'sequelize';
 import { defaultMigrationColumns } from '../config/migrationColumns';
 
-class Organization extends Model {}
+class Organization extends Model {
+  static TYPE = {
+    INDIVIDUAL: 100,
+    COMPANY: 200
+  };
+}
 
 Organization.init(
   {

--- a/take_break_server/package.json
+++ b/take_break_server/package.json
@@ -6,7 +6,7 @@
     "build": "webpack",
     "dev": "webpack --watch --env.NODE_ENV=development",
     "start": "node dist/bundle.js",
-    "test": "jest --watch"
+    "test": "jest --watch --runInBand"
   },
   "dependencies": {
     "bcrypt": "^3.0.6",

--- a/take_break_server/routes/organizations.ts
+++ b/take_break_server/routes/organizations.ts
@@ -5,13 +5,14 @@ import { Organization } from '../models';
 const router = express.Router();
 
 router.post('/', authMiddleware, async (req, res, _next) => {
+  const { name, description, link, type, isSearchable, isJoinable } = req.body;
   const organization = await Organization.create({
-    name: req.body.name,
-    description: req.body.description,
-    link: req.body.link,
-    type: req.body.type,
-    isSearchable: req.body.isSearchable,
-    isJoinable: req.body.isJoinable
+    name,
+    description,
+    link,
+    type,
+    isSearchable,
+    isJoinable
   });
 
   res.status(201).send(organization.toJSON());
@@ -19,6 +20,7 @@ router.post('/', authMiddleware, async (req, res, _next) => {
 
 router.delete('/:id', authMiddleware, async (req, res, _next) => {
   const id = req.params.id;
+
   try {
     const organization = await Organization.findOne({
       where: { id: Number(id) }

--- a/take_break_server/routes/organizations.ts
+++ b/take_break_server/routes/organizations.ts
@@ -1,0 +1,41 @@
+import * as express from 'express';
+import authMiddleware from './middlewares/authMiddleware';
+import { Organization } from '../models';
+
+const router = express.Router();
+
+router.post('/', authMiddleware, async (req, res, _next) => {
+  const organization = await Organization.create({
+    name: req.body.name,
+    description: req.body.description,
+    link: req.body.link,
+    type: req.body.type,
+    isSearchable: req.body.isSearchable,
+    isJoinable: req.body.isJoinable
+  });
+
+  res.status(201).send(organization.toJSON());
+});
+
+router.delete('/:id', authMiddleware, async (req, res, _next) => {
+  const id = req.params.id;
+  try {
+    const organization = await Organization.findOne({
+      where: { id: Number(id) }
+    });
+
+    try {
+      await organization.update({
+        isDeleted: true
+      });
+    } catch (err) {
+      // TODO: error handling;
+    }
+  } catch (err) {
+    // TODO: error handling.
+  }
+
+  res.status(204).send();
+});
+
+export default router;

--- a/take_break_server/test/routes/organizations.test.ts
+++ b/take_break_server/test/routes/organizations.test.ts
@@ -1,0 +1,120 @@
+import app from '../../app';
+import { agent } from 'supertest';
+import prepareDatabase from '../../prepareDatabase';
+import { Organization, User } from '../../models';
+import * as bcrypt from 'bcrypt';
+import * as jwt from 'jsonwebtoken';
+
+let accessToken: string;
+
+// TQDO: apply Faker.js for sample data.
+const name = 'Org Name';
+const description = 'Org description';
+const link = 'Org link';
+const type = Organization.TYPE.INDIVIDUAL;
+const isSearchable = true;
+const isJoinable = true;
+
+// TODO: Write failing case.
+// TODO: Extract common logic. from `it` context.
+beforeEach(async done => {
+  await prepareDatabase();
+
+  // TODO: make sample using factory
+  const hash = bcrypt.hashSync('password', 12);
+  const user = await User.create({
+    name: 'name',
+    password: hash,
+    email: 'test@test.com'
+  });
+  accessToken = jwt.sign({ id: user.id }, process.env.JWT_SECRET as string);
+  done();
+});
+
+afterEach(() => {
+  // TODO: Clear database data.
+  //   - For now, this is ok.
+  //   - Because setup logic drops table. So, it works.
+});
+
+describe('POST /organizations', () => {
+  beforeEach(async done => {
+    done();
+  });
+
+  it('creates a Organization', async done => {
+    // TODO: factory pattern 적용
+
+    const res = await agent(app)
+      .post('/organizations')
+      .send({
+        name,
+        description,
+        ['link' as string]: link,
+        type,
+        isSearchable,
+        isJoinable
+      })
+      .set('Authorization', accessToken)
+      .set('Accept', 'application/json');
+
+    // Status code
+    expect(res.status).toBe(201);
+
+    // Response body
+    expect(res.body.name).toBe(name);
+    expect(res.body.description).toBe(description);
+    expect(res.body.link).toBe(link);
+    expect(res.body.type).toBe(type);
+    expect(res.body.isSearchable).toBe(isSearchable);
+    expect(res.body.isJoinable).toBe(isJoinable);
+
+    // Database
+    const allOrganizationsCount = await Organization.count();
+    expect(allOrganizationsCount).toBe(1);
+
+    done();
+  });
+});
+
+describe('DELETE /organizations/:id', () => {
+  it('mark the record as delete', async done => {
+    // TODO: change as factory function.
+    const organization = await Organization.create({
+      name,
+      description,
+      ['link' as string]: link,
+      type,
+      isSearchable,
+      isJoinable,
+      isDeleted: false
+    });
+
+    // Database: before
+    const allOrganizationsCountBefore = await Organization.count({
+      where: {
+        isDeleted: true
+      }
+    });
+    expect(allOrganizationsCountBefore).toBe(0);
+
+    const res = await agent(app)
+      .del(`/organizations/${organization.id}`)
+      .set('Authorization', accessToken)
+      .set('Accept', 'application/json');
+
+    // Response
+    expect(res.status).toBe(204);
+    expect(res.body).toBeNull;
+
+    // Database: after
+    const allOrganizationsCountAfter = await Organization.count({
+      where: {
+        isDeleted: true
+      }
+    });
+    expect(allOrganizationsCountAfter).toBe(1);
+
+    done();
+  });
+});


### PR DESCRIPTION
## Description

- 조직 생성/삭제 API 및 최소 테스트 추가 (#31)
  - API 요청을 보내면, 데이터베이스에 생성/삭제 되는 최소로직 구현하였습니다.

---

- 다음 작업 진행방향
  1. API 로직 리팩토링
  2. 테스트 리팩토링
  3. 모든 케이스에 대한 테스트 추가
  4. API 로직 완성

---

- 일관성없이 테스트가 실패하는 현상 수정 (#44)
- 테스트 수행전 할일 README 참고

## Related Issue

#31 
#44 

## How Has This Been Tested?

1. npm run test

## Screenshots
