### PR TITLE
path alias 설정

### DIFF
--- a/take_break_client/next.config.js
+++ b/take_break_client/next.config.js
@@ -10,11 +10,18 @@ module.exports = withTypescript(
         javascriptEnabled: true
       },
       webpack(config, options) {
-        config.resolve.alias['components'] = path.join(
-          __dirname,
-          'src/components'
+        const aliases = ['agent', 'components', 'store', 'styles'].reduce(
+          (r, v) => {
+            r[v] = path.join(__dirname, `src/${v}`);
+            return r;
+          },
+          {}
         );
-        config.resolve.alias['styles'] = path.join(__dirname, 'src/styles');
+
+        config.resolve.alias = {
+          ...(config.resolve.alias || {}),
+          ...aliases
+        };
         return config;
       }
     })

--- a/take_break_client/src/components/Register/RegisterForm.tsx
+++ b/take_break_client/src/components/Register/RegisterForm.tsx
@@ -3,7 +3,7 @@ import Router from 'next/router';
 import { Form, Input, Tooltip, Icon, Button } from 'antd';
 import { FormComponentProps } from 'antd/lib/form/Form';
 
-import agent from '../../agent';
+import agent from 'agent';
 
 interface IFormValue {
   username: string;


### PR DESCRIPTION
## Description
- path alias 설정
- `src`에 폴더가 추가되면 `aliases` 배열에 해당 폴더 이름을 추가하면 바로 접근 가능

### 사용 예제
- `src/utils` 폴더 추가
- `next.config.js`파일의 `aliases`에 값 추가
```js
 const aliases = [
  'agent', 
  'components', 
  'store', 
  'styles',
  'utils' // utils 추가
].reduce(...)
```
- 사용
```js
import { ... } from 'utils'; 
```


## Related Issue
#68
## How Has This Been Tested?

1.

2.

3.

## Screenshots
